### PR TITLE
Add dry-run, add tests, fix time issue, fix ImageReferencedByManifestList

### DIFF
--- a/clean-old-ecr-images.sh
+++ b/clean-old-ecr-images.sh
@@ -3,17 +3,62 @@
 # Script to clean ECR repos
 
 ## Usage:
-## ./clean-old-ecr-images.sh <IMAGE-REPO-NAME> <WEEKS-TO-KEEP>
+## ./clean-old-ecr-images.sh <IMAGE-REPO-NAME> <SINCE-TO-KEEP> <ADD-SOMETHING-TO-DRY-RUN (OPTIONAL)>
 ##
 ## Non-interactive, for running in cron or your C.I.:
-## echo "y" | ./clean-old-ecr-images.sh <IMAGE-REPO-NAME> <WEEKS-TO-KEEP>
+## echo "y" | ./clean-old-ecr-images.sh <IMAGE-REPO-NAME> <SINCE-TO-KEEP>
 
 ## Dependencies
 ## Requires jq and aws command line
 ## aws credentials are also needed to access the repo. These can be set up using the "aws configure" command.
 ## Set the region in the parameters below.
 
-REGION="eu-west-1"
+REGION="eu-north-1"
+
+MERGE_MANIFEST_TYPE="application/vnd.docker.distribution.manifest.list.v2+json"
+
+function get_old_images {
+  local DATE_FROM_KEEP=$1
+  local AWS_RAW_JSON=$2
+
+  # Buildkit only tags merged manifest, that's why firstly delete merged manifests and then arch specific images.
+  echo "$(
+    echo "$AWS_RAW_JSON" | 
+    jq -r -c --arg time "$DATE_FROM_KEEP" \
+          --arg type "$MERGE_MANIFEST_TYPE" \
+          '.[] | [.[] | select(.imagePushedAt <= $time)] | sort_by(.imageManifestMediaType != $type, .imagePushedAt) | .[] | {imageDigest, imagePushedAt}')"
+}
+
+function substract_date_unit_from_time {
+  local DATE_UNIT=$1
+  local TIME=$2
+  local CONVERT_TO_SEC=0
+
+  case "${DATE_UNIT: -1}" in
+    d|D) CONVERT_TO_SEC=86400    ;;
+    w|W) CONVERT_TO_SEC=604800   ;;
+    m|M) CONVERT_TO_SEC=2592000  ;;
+    y|Y) CONVERT_TO_SEC=31536000 ;;
+    *)
+      echo "Use the suffix to specify which date to save the images from (day, week, month, year), for example, 1d 3w 5m 3y."
+      exit 1
+    ;;
+  esac
+
+  DATE_UNIT=${DATE_UNIT:0:-1}
+
+  NEW_DATE=$(date -d @$(echo "$TIME - $DATE_UNIT * $CONVERT_TO_SEC" | bc) +"%Y-%m-%dT00:00:00+00:00") || exit 1
+  echo "$NEW_DATE"
+}
+
+if [ $# -eq 0 ]; then
+  # This is small hack to run tests from another file.
+  # When we call explicitly this script we get error, because return is not permit.
+  # When we call some function above from another file, we just skip futher code and jump into function. 
+  { 
+    return
+  } &> /dev/null
+fi
 
 # Check if jq is available
 type jq >/dev/null 2>&1 || { echo >&2 "The jq utility is required for this script to run."; exit 1; }
@@ -22,28 +67,40 @@ type jq >/dev/null 2>&1 || { echo >&2 "The jq utility is required for this scrip
 type aws >/dev/null 2>&1 || { echo >&2 "The aws cli is required for this script to run."; exit 1; }
 
 # Check number of arguments parsed
-if [ $# -ne 2 ]; then
-        echo "Useage ./clean-old-ecr-images.sh <IMAGE-REPO-NAME> <WEEKS-TO-KEEP>"
-        exit 1
+if [ $# -lt 2 ]; then
+  echo "Usage ./clean-old-ecr-images.sh <IMAGE-REPO-NAME> <SINCE-TO-KEEP>"
+  exit 1
 fi
 
-REPO=$1
-WEEKS=$2
-SECONDS=$(echo "$WEEKS * 604800" | bc)
+REPOSITORY=$1
+SINCE_TO_KEEP=$2
 
-read -p "Delete images older than $WEEKS weeks from $REPO (y/n)? " CHOICE
+CURRENT_DATE=$(date +%s)
+DATE_TO_KEEP=$(substract_date_unit_from_time $SINCE_TO_KEEP $CURRENT_DATE)
+
+if [ $? -ne 0 ]; then
+  if [ -n "$DATE_TO_KEEP" ]; then echo "$DATE_TO_KEEP"; fi
+  exit 1
+fi
+
+read -p "Delete images older than $DATE_TO_KEEP from $REPOSITORY (y/n)? " CHOICE
 
 case "$CHOICE" in
   y|Y)
-    WEEKS_AGO=$(echo "$(date +%s)-$SECONDS" | bc)
-    IMAGES=$(aws --region $REGION ecr describe-images --repository-name $REPO --output json | jq '.[]' | jq '.[]' | jq "select (.imagePushedAt < $WEEKS_AGO)" | jq -r '.imageDigest')
+    REPOSITORY_DESCRIBE=$(aws ecr describe-images --repository-name $REPO --output json --region $REGION --no-cli-pager)
+    IMAGES=$(get_old_images $DATE_TO_KEEP "$REPOSITORY_DESCRIBE")
+
     for IMAGE in ${IMAGES[*]}; do
-      echo "Deleting $IMAGE"
-      aws --region $REGION ecr batch-delete-image --repository-name $REPO --image-ids imageDigest=$IMAGE
+      IMAGE_PUSHED_AT=$(echo "$IMAGE" | jq -r ".imagePushedAt")
+      SHA256=$(echo "$IMAGE" | jq -r ".imageDigest")
+
+      echo "$SHA256 $IMAGE_PUSHED_AT"
+      if [ -z "$3" ]; then
+        aws ecr batch-delete-image --repository-name $REPOSITORY --image-ids imageDigest=$SHA256 --region $REGION --no-cli-pager
+      fi
     done
   ;;
 
   *) exit 0  ;;
 esac
 echo "Finished."
-

--- a/test_describe_images.json
+++ b/test_describe_images.json
@@ -1,0 +1,104 @@
+{
+    "imageDetails": [
+        {
+            "registryId": "123456789876",
+            "repositoryName": "repositoryName",
+            "imageDigest": "sha256:1",
+            "imageSizeInBytes": 0,
+            "imagePushedAt": "2023-12-01T15:45:08+03:00",
+            "imageManifestMediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "artifactMediaType": "application/vnd.docker.container.image.v1+json"
+        },
+        {
+            "registryId": "123456789876",
+            "repositoryName": "repositoryName",
+            "imageDigest": "sha256:3",
+            "imageSizeInBytes": 0,
+            "imagePushedAt": "2023-12-05T09:39:15+03:00",
+            "imageManifestMediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "artifactMediaType": "application/vnd.docker.container.image.v1+json"
+        },
+        {
+            "registryId": "123456789876",
+            "repositoryName": "repositoryName",
+            "imageDigest": "sha256:2",
+            "imageTags": [
+                "tag1",
+                "tag2"
+            ],
+            "imageSizeInBytes": 0,
+            "imagePushedAt": "2023-12-03T16:38:24+03:00",
+            "imageManifestMediaType": "application/vnd.docker.distribution.manifest.list.v2+json"
+        },
+        {
+            "registryId": "123456789876",
+            "repositoryName": "repositoryName",
+            "imageDigest": "sha256:4",
+            "imageSizeInBytes": 0,
+            "imagePushedAt": "2023-12-07T07:56:37+03:00",
+            "imageManifestMediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "artifactMediaType": "application/vnd.docker.container.image.v1+json",
+            "lastRecordedPullTime": "2023-12-15T08:05:53.014000+03:00"
+        },
+        {
+            "registryId": "123456789876",
+            "repositoryName": "repositoryName",
+            "imageDigest": "sha256:5",
+            "imageTags": [
+                "tag1",
+                "tag2",
+                "tag3"
+            ],
+            "imageSizeInBytes": 0,
+            "imagePushedAt": "2023-12-09T20:15:15+03:00",
+            "imageManifestMediaType": "application/vnd.docker.distribution.manifest.list.v2+json"
+        },
+        {
+            "registryId": "123456789876",
+            "repositoryName": "repositoryName",
+            "imageDigest": "sha256:6",
+            "imageSizeInBytes": 0,
+            "imagePushedAt": "2023-12-11T20:50:16+03:00",
+            "imageManifestMediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "artifactMediaType": "application/vnd.docker.container.image.v1+json"
+        },
+        {
+            "registryId": "123456789876",
+            "repositoryName": "repositoryName",
+            "imageDigest": "sha256:7",
+            "imageSizeInBytes": 0,
+            "imagePushedAt": "2023-12-13T16:46:36+03:00",
+            "imageManifestMediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "artifactMediaType": "application/vnd.docker.container.image.v1+json"
+        },
+        {
+            "registryId": "123456789876",
+            "repositoryName": "repositoryName",
+            "imageDigest": "sha256:8",
+            "imageSizeInBytes": 0,
+            "imagePushedAt": "2023-12-15T17:20:47+03:00",
+            "imageManifestMediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "artifactMediaType": "application/vnd.docker.container.image.v1+json"
+        },
+        {
+            "registryId": "123456789876",
+            "repositoryName": "repositoryName",
+            "imageDigest": "sha256:9",
+            "imageSizeInBytes": 0,
+            "imagePushedAt": "2023-12-18T16:39:35+03:00",
+            "imageManifestMediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "artifactMediaType": "application/vnd.docker.container.image.v1+json"
+        },
+        {
+            "registryId": "123456789876",
+            "repositoryName": "repositoryName",
+            "imageDigest": "sha256:10",
+            "imageTags": [
+                "tag1"
+            ],
+            "imageSizeInBytes": 0,
+            "imagePushedAt": "2023-12-21T08:27:10+03:00",
+            "imageManifestMediaType": "application/vnd.docker.distribution.manifest.list.v2+json"
+        }
+    ]
+}

--- a/tests.sh
+++ b/tests.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Colors.
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NORMAL='\033[0m'
+
+# Statuses.
+FAILED="${RED}Failed${NORMAL}"
+SUCCESS="${GREEN}Success${NORMAL}"
+
+# Import functions.
+source ./clean-old-ecr-images.sh
+
+# Test time converter.
+TEST_DATE="2023-12-16T00:00:00+00:00"
+
+function test_date_substruct {
+    DATE_UNIT=$1
+    DATE=$(date -d $2 +%s)
+    EXPECTED=$3
+
+    ACTUAL=$(substract_date_unit_from_time $DATE_UNIT $DATE)
+    if [ "$ACTUAL" != "$EXPECTED" ]; then
+        echo -e "$FAILED: ACTUAL=$ACTUAL != EXPECTED=$EXPECTED"
+        return 1
+    fi
+}
+
+test_date_substruct   "1d" $TEST_DATE "2023-12-15T00:00:00+00:00" || exit 1
+test_date_substruct   "0d" $TEST_DATE "2023-12-16T00:00:00+00:00" || exit 1
+test_date_substruct  "39d" $TEST_DATE "2023-11-07T00:00:00+00:00" || exit 1
+test_date_substruct "370d" $TEST_DATE "2022-12-11T00:00:00+00:00" || exit 1
+test_date_substruct   "3w" $TEST_DATE "2023-11-25T00:00:00+00:00" || exit 1
+test_date_substruct   "7w" $TEST_DATE "2023-10-28T00:00:00+00:00" || exit 1
+test_date_substruct   "1m" $TEST_DATE "2023-11-16T00:00:00+00:00" || exit 1
+test_date_substruct   "3m" $TEST_DATE "2023-09-17T00:00:00+00:00" || exit 1
+test_date_substruct   "1y" $TEST_DATE "2022-12-16T00:00:00+00:00" || exit 1
+test_date_substruct   "2y" $TEST_DATE "2021-12-16T00:00:00+00:00" || exit 1
+test_date_substruct  "10y" $TEST_DATE "2013-12-18T00:00:00+00:00" || exit 1
+
+echo -e "$SUCCESS: test to time converter"
+
+# Test data selector. 
+# You can change DATE_TO_KEEP and write extra JSON objects into test_describe_images.json.
+TEST_JSON=$(cat test_describe_images.json)
+DATE_TO_KEEP="2023-12-16T00:00:00+00:00"
+IMAGES=$(get_old_images $DATE_TO_KEEP "$TEST_JSON")
+
+FIRSTLY_MERGED_MANIFESTS="true"
+DATE_TO_KEEP_UNIX=$(date -d $DATE_TO_KEEP '+%s')
+for IMAGE in ${IMAGES[*]}; do
+    IMAGE_PUSHED_AT=$(echo "$IMAGE" | jq -r ".imagePushedAt")
+    SHA256=$(echo "$IMAGE" | jq -r ".imageDigest")
+
+    IMAGE_DATE_UNIX=$(date -d "$IMAGE_PUSHED_AT" +%s)
+
+    if [ $IMAGE_DATE_UNIX -gt $DATE_TO_KEEP_UNIX ]; then
+        echo -e "$FAILED: get image that out of time range"
+        exit 1
+    fi
+
+    IMAGE_INFO=$(echo "$TEST_JSON" | jq --arg sha256 "$SHA256" '.[] | .[] | select(.imageDigest == $sha256)')
+    if [ $(echo "$IMAGE_INFO" | jq -r '.imageManifestMediaType') = "$MERGE_MANIFEST_TYPE" ]; then
+        if [ "$FIRSTLY_MERGED_MANIFESTS" = "false" ]; then
+            echo -e "$FAILED: merge manifest do not go firstry"
+            exit 1
+        fi
+    else
+        FIRSTLY_MERGED_MANIFESTS="false"
+    fi
+done
+
+echo -e "$SUCCESS: test to get images in delete time range"
+echo -e "$SUCCESS: test to get firstly merged manifests"


### PR DESCRIPTION
Hello! You have a nice script. In this pull request I'll try to fix some issues that cause problems with current ECR API version.

### Fixes 

- Nowadays Amazon Web Services does not use UNIX time in `imagePushedAt` JSON field, they moved into iso8601 format. I added some conversion to this format after calculating date.

- We use multi arch builds in our pipelines, it is storaged in Amazon ECR as merged manifest. By default buildkit does not tagged platform depenced images, it only tagged final merged manifest which contains other manifests. To avoid `ImageReferencedByManifestList` error after select we also sorted them to get firstly merged manifests (*thanks to Amazon that we always have consistent data*). This is not fixed this issue, because of time range of pushing, but it helpful to minimize getting this error.

- Add `--no-cli-pager` to off pager.

### Features

- Add new data units to control date threshold to delete images. Now you can use suffixes (d, w, m, y). For example to delete images that pushed more then X days/weed/month/years age use `X(d|w|m|y)`.

- Process error from time converting.

- Add tests.

- Add dry run mode which turn on if add the third optional parameter.
